### PR TITLE
Remove heartrate prefix style

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,8 +27,8 @@ android {
     applicationId "dev.rdnt.m8face"
     minSdk 28
     targetSdk 33
-    versionCode 55
-    versionName '2.12.0'
+    versionCode 56
+    versionName '2.12.1'
   }
 
   buildFeatures {

--- a/app/src/main/java/dev/rdnt/m8face/utils/HorizontalComplication.kt
+++ b/app/src/main/java/dev/rdnt/m8face/utils/HorizontalComplication.kt
@@ -97,14 +97,10 @@ class HorizontalComplication(private val context: Context) : CanvasComplication 
       return
     }
 
-    val isHeartRate =
-      data.dataSource?.className == "com.weartools.heartratecomp.HeartRateComplicationDataSourceService" ||
-        data.dataSource?.className == "com.fitbit.complications.heartrate.HeartRateComplicationDataSourceService"
-
     val isBattery =
       data.dataSource?.className == "com.google.android.clockwork.sysui.experiences.complications.providers.BatteryProviderService"
 
-    val threeDigit = isBattery || isHeartRate
+    val threeDigit = isBattery
 
     var title: String? = null
     var icon: Bitmap? = null

--- a/app/src/main/java/dev/rdnt/m8face/utils/VerticalComplication.kt
+++ b/app/src/main/java/dev/rdnt/m8face/utils/VerticalComplication.kt
@@ -113,11 +113,7 @@ class VerticalComplication(private val context: Context) : CanvasComplication {
     val isBattery =
       data.dataSource?.className == "com.google.android.clockwork.sysui.experiences.complications.providers.BatteryProviderService"
 
-    val isHeartRate =
-      data.dataSource?.className == "com.weartools.heartratecomp.HeartRateComplicationDataSourceService" ||
-        data.dataSource?.className == "com.fitbit.complications.heartrate.HeartRateComplicationDataSourceService"
-
-    val threeDigit = isBattery || isHeartRate
+    val threeDigit = isBattery
 
     var title: String? = null
     var icon: Bitmap? = null


### PR DESCRIPTION
It seems, at least on the OG Pixel Watch on WearOS 4, that the heartrate complication provided from FitBit usually has a null data source. The data source is reported as not always being present on the source docs, so let's remove it at least from the heartrate complication for now.

If the battery complication appears to behave the same at some point the prefix paint handling should be removed altogether.